### PR TITLE
Bump runtime version

### DIFF
--- a/org.baedert.corebird.json
+++ b/org.baedert.corebird.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.baedert.corebird",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "3.24",
+  "runtime-version": "3.26",
   "sdk" : "org.gnome.Sdk",
   "command" : "corebird",
   "rename-icon" : "corebird",


### PR DESCRIPTION
It's hard to follow Chelsea Manning (and others) when all emojis
show up in black & white, so bump the platform version to the
last stable release that introduced support for color emojis.